### PR TITLE
peer: remove webrtcsupport

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
         "exports",
         "console",
         "Buffer",
-        "module"
+        "module",
+        "RTCPeerConnection"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -8,25 +8,25 @@
   "main": "./src/simplewebrtc.js",
   "description": "World's easiest webrtc",
   "dependencies": {
+    "attachmediastream": "^2.0.0",
     "filetransfer": "^2.0.4",
     "localmedia": "^4.0.0",
+    "mockconsole": "0.0.1",
     "rtcpeerconnection": "^8.0.0",
-    "webrtcsupport": "^2.2.0",
-    "wildemitter": "^1.2.0",
     "socket.io-client": "1.3.7",
-    "attachmediastream": "^2.0.0",
-    "mockconsole": "0.0.1"
+    "webrtcsupport": "^2.2.0",
+    "wildemitter": "^1.2.0"
   },
   "devDependencies": {
     "browserify": "^13.1.0",
     "precommit-hook": "^3.0.0",
     "request": "^2.72.0",
+    "stupid-server": "^0.2.2",
     "tape": "^4.0.0",
     "testling": "^1.7.1",
     "travis-multirunner": "^4.0.0",
     "uglify-js": "^2.7.3",
-    "stupid-server": "^0.2.2",
-    "webrtc-adapter": "^4.0.0",
+    "webrtc-adapter": "^4.2.2",
     "webrtc-testbed": "git+https://github.com/fippo/testbed.git"
   },
   "peerDependencies": {


### PR DESCRIPTION
no longer changes the signaling protocol but does not make big attempts to support edge