### PR TITLE
peer: emit unknown events

### DIFF
--- a/src/peer.js
+++ b/src/peer.js
@@ -139,6 +139,8 @@ Peer.prototype.handleMessage = function (message) {
         this.parent.emit('unmute', {id: message.from, name: message.payload.name});
     } else if (message.type === 'endOfCandidates') {
         this.pc.pc.addIceCandidate(undefined);
+    } else {
+        this.parent.emit(message.type, message.payload);
     }
 };
 

--- a/test/selenium/p2p.js
+++ b/test/selenium/p2p.js
@@ -67,8 +67,8 @@ function waitAllVideosHaveEnoughData(driver) {
 function testP2P(browserA, browserB, t) {
     const room = 'testing_' + Math.floor(Math.random() * 100000);
 
-    const driverA = seleniumHelpers.buildDriver(browserA, {bver: process.env.BVER});
-    const driverB = seleniumHelpers.buildDriver(browserB, {bver: process.env.BVER});
+    const driverA = seleniumHelpers.buildDriver(browserA, {bver: process.env.BVER, noSandbox: true});
+    const driverB = seleniumHelpers.buildDriver(browserB, {bver: process.env.BVER, noSandbox: true});
     const drivers = [driverA, driverB];
 
     return Promise.all(drivers.map(driver => doJoin(driver, room)))


### PR DESCRIPTION
@tgabi333 @xdumaine not sure if this is a good idea. If you want to shoot yourself in the foot this makes it very easy. But we don't filter sendToAll events so they just end up not being handled in this place